### PR TITLE
Add publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,48 @@
+name: publish package
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install apt dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install libcurl4-openssl-dev libssl-dev
+      - uses: actions/checkout@v6.0.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
+        with:
+          # Install a specific version of uv.
+          version: "0.10.9"
+          enable-cache: true
+
+      - name: "Set up Python"
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version-file: ".python-version"
+
+      - name: Install dependencies
+        run: |
+          cd aieng-agents
+          uv venv .venv
+          source .venv/bin/activate
+          uv sync --all-extras --dev
+
+      - name: Build package
+        run: cd aieng-agents && source .venv/bin/activate && uv build
+
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages-dir: dist/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,9 +4,8 @@ permissions:
   pull-requests: write
 
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types: [published]
 
 jobs:
   deploy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: 'v0.12.2'
     hooks:
-    - id: ruff
+    - id: ruff-check
       args: [--fix, --exit-non-zero-on-fix]
       types_or: [python, jupyter]
     - id: ruff-format


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for publishing the package when a new version tag is pushed, and updates the pre-commit configuration to use the correct Ruff hook for linting.

**Continuous Integration / Deployment:**

* Added a `.github/workflows/publish.yml` workflow to automate package publishing on PyPI when a new tag is pushed. This workflow sets up dependencies, installs Python and the `uv` package manager, builds the package, and publishes it using the PyPI API token.

**Code Quality / Tooling:**

* Updated `.pre-commit-config.yaml` to use the `ruff-check` hook instead of the deprecated `ruff` hook for Python linting, ensuring compatibility with the latest Ruff pre-commit integration.