### PR TITLE
Bump python-multipart from 0.0.22 to 0.0.26 and fix security vulnerabilities

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3494,7 +3494,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "(python_full_version < '3.14' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [


### PR DESCRIPTION
## Summary

- Bump python-multipart from 0.0.22 to 0.0.26 (original Dependabot change)
- Fix all pip-audit security vulnerabilities found in CI:
  - aiohttp 3.13.3 → 3.13.5 (GHSA-p998-jp59-783m et al.)
  - authlib 1.6.9 → 1.6.11 (GHSA-jj8c-mmj3-mmgv)
  - cryptography 46.0.5 → 46.0.7 (GHSA-m959-cc7f-wv43, GHSA-p423-j2cm-9vmq)
  - pillow 12.1.1 → 12.2.0 (GHSA-whj4-6x5x-4v2j)
  - pyasn1 0.6.2 → 0.6.3 (GHSA-jr27-m4p2-rc6r)
  - pygments 2.19.2 → 2.20.0 (GHSA-5239-wwwm-4pmq)
  - pytest 8.4.2 → 9.0.3 (GHSA-6w46-j5rx-g56g)
  - requests 2.32.5 → 2.33.1 (GHSA-gc5v-m9x4-r6x2)
  - transformers 4.57.1 → 5.5.4 (GHSA-69w3-r845-3855)

## Test plan

- [x] `uv run pip-audit` shows no known vulnerabilities
- [x] `uv lock` resolves cleanly with updated constraints
- [ ] CI passes (code checks, unit tests, docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)