### PR TITLE
Bump aiohttp from 3.13.3 to 3.13.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ docs = [
 [tool.uv]
 default-groups = ["dev", "docs"]
 constraint-dependencies = [
-    "aiohttp>=3.13.4",      # GHSA-p998-jp59-783m, GHSA-hcc4-c3v8-rx92, GHSA-m5qp-6w8w-w647, GHSA-3wq7-rqq7-wx6j, GHSA-mwh4-6h8g-pg8w, GHSA-966j-vmvw-g2g9, GHSA-63hf-3vf5-4wqf, GHSA-c427-h43c-vf67, GHSA-w2fm-2cpv-w7v5, GHSA-2vrm-gr82-f7m5
+    "aiohttp>=3.13.5",      # GHSA-p998-jp59-783m, GHSA-hcc4-c3v8-rx92, GHSA-m5qp-6w8w-w647, GHSA-3wq7-rqq7-wx6j, GHSA-mwh4-6h8g-pg8w, GHSA-966j-vmvw-g2g9, GHSA-63hf-3vf5-4wqf, GHSA-c427-h43c-vf67, GHSA-w2fm-2cpv-w7v5, GHSA-2vrm-gr82-f7m5
     "authlib>=1.6.11",      # GHSA-xm59-rqc7-hhvf GHSA-7gcm-g887-7qv7
     "cryptography>=46.0.7", # GHSA-m959-cc7f-wv43, GHSA-p423-j2cm-9vmq
     "pyasn1>=0.6.3",        # GHSA-jr27-m4p2-rc6r

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ members = [
     "aieng-agents",
 ]
 constraints = [
-    { name = "aiohttp", specifier = ">=3.13.4" },
+    { name = "aiohttp", specifier = ">=3.13.5" },
     { name = "authlib", specifier = ">=1.6.11" },
     { name = "cryptography", specifier = ">=46.0.7" },
     { name = "pyasn1", specifier = ">=0.6.3" },


### PR DESCRIPTION
Bumps aiohttp from 3.13.3 to 3.13.4.

Also fixes pip-audit security vulnerabilities:
- authlib 1.6.9 -> 1.6.11 (GHSA-jj8c-mmj3-mmgv)
- cryptography 46.0.5 -> 46.0.7 (GHSA-m959-cc7f-wv43, GHSA-p423-j2cm-9vmq)
- pillow 12.1.1 -> 12.2.0 (GHSA-whj4-6x5x-4v2j)
- pyasn1 0.6.2 -> 0.6.3 (GHSA-jr27-m4p2-rc6r)
- pygments 2.19.2 -> 2.20.0 (GHSA-5239-wwwm-4pmq)
- pytest 8.4.2 -> 9.0.3 (GHSA-6w46-j5rx-g56g)
- python-multipart 0.0.22 -> 0.0.26 (GHSA-mj87-hwqh-73pj)
- requests 2.32.5 -> 2.33.1 (GHSA-gc5v-m9x4-r6x2)
- transformers 4.57.1 -> 5.5.4 (GHSA-69w3-r845-3855)

🤖 Fixed by aieng-bot